### PR TITLE
Set up workflow for automatic extension publishing

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,46 @@
+name: Publish VS Code Extension
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+
+    - name: Install dependencies
+      run: npm install -g vsce
+
+    - name: Determine version bump from commit message
+      id: version
+      run: |
+        COMMIT_MSG=$(git log -1 --pretty=%B)
+        echo "Last commit: $COMMIT_MSG"
+        if [[ "$COMMIT_MSG" == *"[major]"* ]]; then
+          echo "bump=major" >> $GITHUB_OUTPUT
+        elif [[ "$COMMIT_MSG" == *"[minor]"* ]]; then
+          echo "bump=minor" >> $GITHUB_OUTPUT
+        else
+          echo "bump=patch" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Bump version in package.json
+      run: |
+        npm version ${{ steps.version.outputs.bump }} --no-git-tag-version
+        VERSION=$(node -p "require('./package.json').version")
+        echo "📦 Bumped version to $VERSION"
+
+    - name: Publish to VS Code Marketplace
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      run: vsce publish --pat $VSCE_PAT


### PR DESCRIPTION
## Notes
- `npm test` fails because no test script is defined.

## Summary
- add `publish-extension` workflow to automate version bumping and publishing to the VS Code Marketplace
- fix version bump log quoting so it doesn't error